### PR TITLE
Fixing travis build (hopefully)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 # TODO require puppet-lint
 language: ruby
 rvm: 
- - 1.8.7
-# - 1.9.3
+# - 1.8.7
+ - 1.9.3
 branches:
   only:
     - master


### PR DESCRIPTION
activesupport (4.0.0) requires Ruby version >= 1.9.3.
