### PR TITLE
Avoid changing TZ in date-world

### DIFF
--- a/bin/date-world
+++ b/bin/date-world
@@ -3,7 +3,7 @@
 # Down under generated with:
 # Generated: http://www.sunnyneo.com/upsidedowntext.php?word=Down+Under
 
-echo -en "UTC (God time):        "; export TZ=UTC; date
-echo -en "Pacific (Google time): "; export TZ=America/Los_Angeles ; date
-echo -en "Rome (Caesar):         "; export TZ=Europe/Rome ; date
-echo -en "Sydney: (ɹəpun uʍop)   "; export TZ=Australia/Sydney ; date
+echo -en "UTC (God time):        "; TZ=UTC date
+echo -en "Pacific (Google time): "; TZ=America/Los_Angeles date
+echo -en "Rome (Caesar):         "; TZ=Europe/Rome date
+echo -en "Sydney: (ɹəpun uʍop)   "; TZ=Australia/Sydney date


### PR DESCRIPTION
If exporting changes to TZ date-world ends up setting TZ to Sydney,
whatever it was previously. We can have the same effect by just
setting TZ for the command's duration.
