### PR TITLE
remove export to keep the caller environment untouched

### DIFF
--- a/bin/date-world
+++ b/bin/date-world
@@ -3,7 +3,7 @@
 # Down under generated with:
 # Generated: http://www.sunnyneo.com/upsidedowntext.php?word=Down+Under
 
-echo -en "UTC (God time):        "; export TZ=UTC; date
-echo -en "Pacific (Google time): "; export TZ=America/Los_Angeles ; date
-echo -en "Rome (Caesar):         "; export TZ=Europe/Rome ; date
-echo -en "Sydney: (ɹəpun uʍop)   "; export TZ=Australia/Sydney ; date
+echo -en "UTC (God time):        "; TZ=UTC date
+echo -en "Pacific (Google time): "; TZ=America/Los_Angeles date
+echo -en "Rome (Caesar):         "; TZ=Europe/Rome date
+echo -en "Sydney: (ɹəpun uʍop)   "; TZ=Australia/Sydney date


### PR DESCRIPTION
with export TZ=Australia/Sydney being last command, the caller environment would ended up "ɹəpun uʍop". 

Although, this is the best TZ, it might not be desired to change everything to it. ;-)